### PR TITLE
Add missing ruby2_keywords in extra place

### DIFF
--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -13,7 +13,7 @@ module Faraday
       self.load_error = e
     end
 
-    def new(*)
+    ruby2_keywords def new(*)
       unless loaded?
         raise "missing dependency for #{self}: #{load_error.message}"
       end


### PR DESCRIPTION
In https://github.com/lostisland/faraday/pull/1153 support for forwarding splat parameters was added, but the `DependencyLoader` update was later undone in https://github.com/lostisland/faraday/pull/1211. According to that last PR's comments, ruby 2.7 removed the warnings that the initial PR addressed. They did try to apply a more general fix on https://github.com/lostisland/faraday/pull/1209 but that PR was never merged. However, with the release of ruby 3.2.0 and the [changes on `ruby2_keywords`](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) this code no longer works, raising `ArgumentError` exceptions.

This PR fixes this issue for v1. Faraday v2 changed radically, and the `DependencyLoader` class no longer exists.